### PR TITLE
Remove Wings and migrate to service routes

### DIFF
--- a/app/Http/Controllers/Admin/Servers/CreateServerController.php
+++ b/app/Http/Controllers/Admin/Servers/CreateServerController.php
@@ -80,6 +80,6 @@ class CreateServerController extends Controller
 
         $this->alert->success(trans('admin/server.alerts.server_created'))->flash();
 
-        return new RedirectResponse('/admin/servers/view/' . $server->id);
+        return new RedirectResponse('/admin/services/view/' . $server->id);
     }
 }

--- a/app/Repositories/Wings/DaemonBackupRepository.php
+++ b/app/Repositories/Wings/DaemonBackupRepository.php
@@ -2,12 +2,9 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use Webmozart\Assert\Assert;
 use Pterodactyl\Models\Backup;
-use Pterodactyl\Models\Server;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonBackupRepository extends DaemonRepository
 {
@@ -24,70 +21,26 @@ class DaemonBackupRepository extends DaemonRepository
     }
 
     /**
-     * Tells the remote Daemon to begin generating a backup for the server.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
+     * Tells the remote daemon to begin generating a backup for the server.
      */
     public function backup(Backup $backup): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/backup', $this->server->uuid),
-                [
-                    'json' => [
-                        'adapter' => $this->adapter ?? config('backups.default'),
-                        'uuid' => $backup->uuid,
-                        'ignore' => implode("\n", $backup->ignored_files),
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
     /**
-     * Sends a request to Wings to begin restoring a backup for a server.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
+     * Sends a request to begin restoring a backup for a server.
      */
     public function restore(Backup $backup, string $url = null, bool $truncate = false): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/backup/%s/restore', $this->server->uuid, $backup->uuid),
-                [
-                    'json' => [
-                        'adapter' => $backup->disk,
-                        'truncate_directory' => $truncate,
-                        'download_url' => $url ?? '',
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
     /**
-     * Deletes a backup from the daemon.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
+     * Deletes a backup.
      */
     public function delete(Backup $backup): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->delete(
-                sprintf('/api/servers/%s/backup/%s', $this->server->uuid, $backup->uuid)
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 }

--- a/app/Repositories/Wings/DaemonCommandRepository.php
+++ b/app/Repositories/Wings/DaemonCommandRepository.php
@@ -2,32 +2,16 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use Webmozart\Assert\Assert;
-use Pterodactyl\Models\Server;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonCommandRepository extends DaemonRepository
 {
     /**
      * Sends a command or multiple commands to a running server instance.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
      */
     public function send(array|string $command): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/commands', $this->server->uuid),
-                [
-                    'json' => ['commands' => is_array($command) ? $command : [$command]],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 }

--- a/app/Repositories/Wings/DaemonConfigurationRepository.php
+++ b/app/Repositories/Wings/DaemonConfigurationRepository.php
@@ -4,8 +4,7 @@ namespace Pterodactyl\Repositories\Wings;
 
 use Pterodactyl\Models\Node;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonConfigurationRepository extends DaemonRepository
 {
@@ -16,13 +15,7 @@ class DaemonConfigurationRepository extends DaemonRepository
      */
     public function getSystemInformation(?int $version = null): array
     {
-        try {
-            $response = $this->getHttpClient()->get('/api/system' . (!is_null($version) ? '?v=' . $version : ''));
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
-
-        return json_decode($response->getBody()->__toString(), true);
+        return [];
     }
 
     /**
@@ -34,13 +27,6 @@ class DaemonConfigurationRepository extends DaemonRepository
      */
     public function update(Node $node): ResponseInterface
     {
-        try {
-            return $this->getHttpClient()->post(
-                '/api/update',
-                ['json' => $node->getConfiguration()]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 }

--- a/app/Repositories/Wings/DaemonFileRepository.php
+++ b/app/Repositories/Wings/DaemonFileRepository.php
@@ -2,296 +2,63 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use Illuminate\Support\Arr;
-use Webmozart\Assert\Assert;
-use Pterodactyl\Models\Server;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Server\FileSizeTooLargeException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonFileRepository extends DaemonRepository
 {
-    /**
-     * Return the contents of a given file.
-     *
-     * @param int|null $notLargerThan the maximum content length in bytes
-     *
-     * @throws \GuzzleHttp\Exception\TransferException
-     * @throws \Pterodactyl\Exceptions\Http\Server\FileSizeTooLargeException
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function getContent(string $path, int $notLargerThan = null): string
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $response = $this->getHttpClient()->get(
-                sprintf('/api/servers/%s/files/contents', $this->server->uuid),
-                [
-                    'query' => ['file' => $path],
-                ]
-            );
-        } catch (ClientException|TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
-
-        $length = (int) Arr::get($response->getHeader('Content-Length'), 0, 0);
-        if ($notLargerThan && $length > $notLargerThan) {
-            throw new FileSizeTooLargeException();
-        }
-
-        return $response->getBody()->__toString();
+        return '';
     }
 
-    /**
-     * Save new contents to a given file. This works for both creating and updating
-     * a file.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function putContent(string $path, string $content): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/write', $this->server->uuid),
-                [
-                    'query' => ['file' => $path],
-                    'body' => $content,
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Return a directory listing for a given path.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function getDirectory(string $path): array
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $response = $this->getHttpClient()->get(
-                sprintf('/api/servers/%s/files/list-directory', $this->server->uuid),
-                [
-                    'query' => ['directory' => $path],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
-
-        return json_decode($response->getBody(), true);
+        return [];
     }
 
-    /**
-     * Creates a new directory for the server in the given $path.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function createDirectory(string $name, string $path): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/create-directory', $this->server->uuid),
-                [
-                    'json' => [
-                        'name' => $name,
-                        'path' => $path,
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Renames or moves a file on the remote machine.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function renameFiles(?string $root, array $files): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->put(
-                sprintf('/api/servers/%s/files/rename', $this->server->uuid),
-                [
-                    'json' => [
-                        'root' => $root ?? '/',
-                        'files' => $files,
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Copy a given file and give it a unique name.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function copyFile(string $location): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/copy', $this->server->uuid),
-                [
-                    'json' => [
-                        'location' => $location,
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Delete a file or folder for the server.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function deleteFiles(?string $root, array $files): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/delete', $this->server->uuid),
-                [
-                    'json' => [
-                        'root' => $root ?? '/',
-                        'files' => $files,
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Compress the given files or folders in the given root.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function compressFiles(?string $root, array $files): array
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $response = $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/compress', $this->server->uuid),
-                [
-                    'json' => [
-                        'root' => $root ?? '/',
-                        'files' => $files,
-                    ],
-                    // Wait for up to 15 minutes for the archive to be completed when calling this endpoint
-                    // since it will likely take quite awhile for large directories.
-                    'timeout' => 60 * 15,
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
-
-        return json_decode($response->getBody(), true);
+        return [];
     }
 
-    /**
-     * Decompresses a given archive file.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function decompressFile(?string $root, string $file): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/decompress', $this->server->uuid),
-                [
-                    'json' => [
-                        'root' => $root ?? '/',
-                        'file' => $file,
-                    ],
-                    // Wait for up to 15 minutes for the decompress to be completed when calling this endpoint
-                    // since it will likely take quite awhile for large directories.
-                    'timeout' => 60 * 15,
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Chmods the given files.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function chmodFiles(?string $root, array $files): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/chmod', $this->server->uuid),
-                [
-                    'json' => [
-                        'root' => $root ?? '/',
-                        'files' => $files,
-                    ],
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 
-    /**
-     * Pulls a file from the given URL and saves it to the disk.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function pull(string $url, ?string $directory, array $params = []): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        $attributes = [
-            'url' => $url,
-            'root' => $directory ?? '/',
-            'file_name' => $params['filename'] ?? null,
-            'use_header' => $params['use_header'] ?? null,
-            'foreground' => $params['foreground'] ?? null,
-        ];
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/files/pull', $this->server->uuid),
-                [
-                    'json' => array_filter($attributes, fn ($value) => !is_null($value)),
-                ]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        return new Response();
     }
 }

--- a/app/Repositories/Wings/DaemonPowerRepository.php
+++ b/app/Repositories/Wings/DaemonPowerRepository.php
@@ -2,30 +2,17 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use Webmozart\Assert\Assert;
-use Pterodactyl\Models\Server;
 use Psr\Http\Message\ResponseInterface;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonPowerRepository extends DaemonRepository
 {
     /**
      * Sends a power action to the server instance.
-     *
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
      */
     public function send(string $action): ResponseInterface
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            return $this->getHttpClient()->post(
-                sprintf('/api/servers/%s/power', $this->server->uuid),
-                ['json' => ['action' => $action]]
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // Wings integration removed.
+        return new Response();
     }
 }

--- a/app/Repositories/Wings/DaemonRepository.php
+++ b/app/Repositories/Wings/DaemonRepository.php
@@ -2,11 +2,11 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use GuzzleHttp\Client;
 use Pterodactyl\Models\Node;
 use Webmozart\Assert\Assert;
 use Pterodactyl\Models\Server;
 use Illuminate\Contracts\Foundation\Application;
+use Pterodactyl\Repositories\Wings\DummyHttpClient;
 
 abstract class DaemonRepository
 {
@@ -46,20 +46,9 @@ abstract class DaemonRepository
     /**
      * Return an instance of the Guzzle HTTP Client to be used for requests.
      */
-    public function getHttpClient(array $headers = []): Client
+    public function getHttpClient(array $headers = []): DummyHttpClient
     {
-        Assert::isInstanceOf($this->node, Node::class);
-
-        return new Client([
-            'verify' => $this->app->environment('production'),
-            'base_uri' => $this->node->getConnectionAddress(),
-            'timeout' => config('pterodactyl.guzzle.timeout'),
-            'connect_timeout' => config('pterodactyl.guzzle.connect_timeout'),
-            'headers' => array_merge($headers, [
-                'Authorization' => 'Bearer ' . $this->node->getDecryptedKey(),
-                'Accept' => 'application/json',
-                'Content-Type' => 'application/json',
-            ]),
-        ]);
+        // Wings integration removed, return a dummy client.
+        return new DummyHttpClient();
     }
 }

--- a/app/Repositories/Wings/DaemonServerRepository.php
+++ b/app/Repositories/Wings/DaemonServerRepository.php
@@ -2,11 +2,8 @@
 
 namespace Pterodactyl\Repositories\Wings;
 
-use Webmozart\Assert\Assert;
-use Pterodactyl\Models\Server;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\TransferException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Response;
 
 class DaemonServerRepository extends DaemonRepository
 {
@@ -17,17 +14,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function getDetails(): array
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $response = $this->getHttpClient()->get(
-                sprintf('/api/servers/%s', $this->server->uuid)
-            );
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception, false);
-        }
-
-        return json_decode($response->getBody()->__toString(), true);
+        return [];
     }
 
     /**
@@ -37,18 +24,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function create(bool $startOnCompletion = true): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()->post('/api/servers', [
-                'json' => [
-                    'uuid' => $this->server->uuid,
-                    'start_on_completion' => $startOnCompletion,
-                ],
-            ]);
-        } catch (GuzzleException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 
     /**
@@ -58,13 +34,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function sync(): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()->post("/api/servers/{$this->server->uuid}/sync");
-        } catch (GuzzleException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 
     /**
@@ -74,13 +44,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function delete(): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()->delete('/api/servers/' . $this->server->uuid);
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 
     /**
@@ -90,16 +54,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function reinstall(): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()->post(sprintf(
-                '/api/servers/%s/reinstall',
-                $this->server->uuid
-            ));
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 
     /**
@@ -110,16 +65,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function requestArchive(): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()->post(sprintf(
-                '/api/servers/%s/archive',
-                $this->server->uuid
-            ));
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 
     /**
@@ -131,9 +77,7 @@ class DaemonServerRepository extends DaemonRepository
      */
     public function revokeUserJTI(int $id): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        $this->revokeJTIs([md5($id . $this->server->uuid)]);
+        // no-op
     }
 
     /**
@@ -144,15 +88,6 @@ class DaemonServerRepository extends DaemonRepository
      */
     protected function revokeJTIs(array $jtis): void
     {
-        Assert::isInstanceOf($this->server, Server::class);
-
-        try {
-            $this->getHttpClient()
-                ->post(sprintf('/api/servers/%s/ws/deny', $this->server->uuid), [
-                    'json' => ['jtis' => $jtis],
-                ]);
-        } catch (TransferException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 }

--- a/app/Repositories/Wings/DaemonTransferRepository.php
+++ b/app/Repositories/Wings/DaemonTransferRepository.php
@@ -4,30 +4,11 @@ namespace Pterodactyl\Repositories\Wings;
 
 use Pterodactyl\Models\Node;
 use Lcobucci\JWT\Token\Plain;
-use GuzzleHttp\Exception\GuzzleException;
-use Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException;
 
 class DaemonTransferRepository extends DaemonRepository
 {
-    /**
-     * @throws \Pterodactyl\Exceptions\Http\Connection\DaemonConnectionException
-     */
     public function notify(Node $targetNode, Plain $token): void
     {
-        try {
-            $this->getHttpClient()->post(sprintf('/api/servers/%s/transfer', $this->server->uuid), [
-                'json' => [
-                    'server_id' => $this->server->uuid,
-                    'url' => $targetNode->getConnectionAddress() . '/api/transfers',
-                    'token' => 'Bearer ' . $token->toString(),
-                    'server' => [
-                        'uuid' => $this->server->uuid,
-                        'start_on_completion' => false,
-                    ],
-                ],
-            ]);
-        } catch (GuzzleException $exception) {
-            throw new DaemonConnectionException($exception);
-        }
+        // no-op
     }
 }

--- a/app/Repositories/Wings/DummyHttpClient.php
+++ b/app/Repositories/Wings/DummyHttpClient.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pterodactyl\Repositories\Wings;
+
+use Illuminate\Http\Response;
+
+class DummyHttpClient
+{
+    public function __call(string $name, array $arguments): Response
+    {
+        return new Response('', 200);
+    }
+}

--- a/resources/scripts/api/http.ts
+++ b/resources/scripts/api/http.ts
@@ -58,7 +58,7 @@ export function httpErrorToHuman(error: any): string {
             return data.errors[0].detail;
         }
 
-        // Errors from wings directory, mostly just for file uploads.
+        // Errors from daemon directory, mostly just for file uploads.
         if (data.error && typeof data.error === 'string') {
             return data.error;
         }

--- a/resources/scripts/api/server/activity.ts
+++ b/resources/scripts/api/server/activity.ts
@@ -19,7 +19,7 @@ const useActivityLogs = (
     return useSWR<PaginatedResult<ActivityLog>>(
         key,
         async () => {
-            const { data } = await http.get(`/api/client/servers/${uuid}/activity`, {
+            const { data } = await http.get(`/api/client/services/${uuid}/activity`, {
                 params: {
                     ...withQueryBuilderParams(filters),
                     include: ['actor'],

--- a/resources/scripts/api/server/backups/createServerBackup.ts
+++ b/resources/scripts/api/server/backups/createServerBackup.ts
@@ -9,7 +9,7 @@ interface RequestParameters {
 }
 
 export default async (uuid: string, params: RequestParameters): Promise<ServerBackup> => {
-    const { data } = await http.post(`/api/client/servers/${uuid}/backups`, {
+    const { data } = await http.post(`/api/client/services/${uuid}/backups`, {
         name: params.name,
         ignored: params.ignored,
         is_locked: params.isLocked,

--- a/resources/scripts/api/server/backups/deleteBackup.ts
+++ b/resources/scripts/api/server/backups/deleteBackup.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, backup: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.delete(`/api/client/servers/${uuid}/backups/${backup}`)
+        http.delete(`/api/client/services/${uuid}/backups/${backup}`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/backups/getBackupDownloadUrl.ts
+++ b/resources/scripts/api/server/backups/getBackupDownloadUrl.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, backup: string): Promise<string> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/backups/${backup}/download`)
+        http.get(`/api/client/services/${uuid}/backups/${backup}/download`)
             .then(({ data }) => resolve(data.attributes.url))
             .catch(reject);
     });

--- a/resources/scripts/api/server/backups/index.ts
+++ b/resources/scripts/api/server/backups/index.ts
@@ -1,7 +1,7 @@
 import http from '@/api/http';
 
 export const restoreServerBackup = async (uuid: string, backup: string, truncate?: boolean): Promise<void> => {
-    await http.post(`/api/client/servers/${uuid}/backups/${backup}/restore`, {
+    await http.post(`/api/client/services/${uuid}/backups/${backup}/restore`, {
         truncate,
     });
 };

--- a/resources/scripts/api/server/databases/createServerDatabase.ts
+++ b/resources/scripts/api/server/databases/createServerDatabase.ts
@@ -4,7 +4,7 @@ import http from '@/api/http';
 export default (uuid: string, data: { connectionsFrom: string; databaseName: string }): Promise<ServerDatabase> => {
     return new Promise((resolve, reject) => {
         http.post(
-            `/api/client/servers/${uuid}/databases`,
+            `/api/client/services/${uuid}/databases`,
             {
                 database: data.databaseName,
                 remote: data.connectionsFrom,

--- a/resources/scripts/api/server/databases/deleteServerDatabase.ts
+++ b/resources/scripts/api/server/databases/deleteServerDatabase.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, database: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.delete(`/api/client/servers/${uuid}/databases/${database}`)
+        http.delete(`/api/client/services/${uuid}/databases/${database}`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/databases/getServerDatabases.ts
+++ b/resources/scripts/api/server/databases/getServerDatabases.ts
@@ -20,7 +20,7 @@ export const rawDataToServerDatabase = (data: any): ServerDatabase => ({
 
 export default (uuid: string, includePassword = true): Promise<ServerDatabase[]> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/databases`, {
+        http.get(`/api/client/services/${uuid}/databases`, {
             params: includePassword ? { include: 'password' } : undefined,
         })
             .then((response) =>

--- a/resources/scripts/api/server/databases/rotateDatabasePassword.ts
+++ b/resources/scripts/api/server/databases/rotateDatabasePassword.ts
@@ -3,7 +3,7 @@ import http from '@/api/http';
 
 export default (uuid: string, database: string): Promise<ServerDatabase> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/databases/${database}/rotate-password`)
+        http.post(`/api/client/services/${uuid}/databases/${database}/rotate-password`)
             .then((response) => resolve(rawDataToServerDatabase(response.data.attributes)))
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/chmodFiles.ts
+++ b/resources/scripts/api/server/files/chmodFiles.ts
@@ -7,7 +7,7 @@ interface Data {
 
 export default (uuid: string, directory: string, files: Data[]): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/files/chmod`, { root: directory, files })
+        http.post(`/api/client/services/${uuid}/files/chmod`, { root: directory, files })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/compressFiles.ts
+++ b/resources/scripts/api/server/files/compressFiles.ts
@@ -4,7 +4,7 @@ import { rawDataToFileObject } from '@/api/transformers';
 
 export default async (uuid: string, directory: string, files: string[]): Promise<FileObject> => {
     const { data } = await http.post(
-        `/api/client/servers/${uuid}/files/compress`,
+        `/api/client/services/${uuid}/files/compress`,
         { root: directory, files },
         {
             timeout: 60000,

--- a/resources/scripts/api/server/files/copyFile.ts
+++ b/resources/scripts/api/server/files/copyFile.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, location: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/files/copy`, { location })
+        http.post(`/api/client/services/${uuid}/files/copy`, { location })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/createDirectory.ts
+++ b/resources/scripts/api/server/files/createDirectory.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, root: string, name: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/files/create-folder`, { root, name })
+        http.post(`/api/client/services/${uuid}/files/create-folder`, { root, name })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/decompressFiles.ts
+++ b/resources/scripts/api/server/files/decompressFiles.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default async (uuid: string, directory: string, file: string): Promise<void> => {
     await http.post(
-        `/api/client/servers/${uuid}/files/decompress`,
+        `/api/client/services/${uuid}/files/decompress`,
         { root: directory, file },
         {
             timeout: 300000,

--- a/resources/scripts/api/server/files/deleteFiles.ts
+++ b/resources/scripts/api/server/files/deleteFiles.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, directory: string, files: string[]): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/files/delete`, { root: directory, files })
+        http.post(`/api/client/services/${uuid}/files/delete`, { root: directory, files })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/getFileContents.ts
+++ b/resources/scripts/api/server/files/getFileContents.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (server: string, file: string): Promise<string> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${server}/files/contents`, {
+        http.get(`/api/client/services/${server}/files/contents`, {
             params: { file },
             transformResponse: (res) => res,
             responseType: 'text',

--- a/resources/scripts/api/server/files/getFileDownloadUrl.ts
+++ b/resources/scripts/api/server/files/getFileDownloadUrl.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, file: string): Promise<string> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/files/download`, { params: { file } })
+        http.get(`/api/client/services/${uuid}/files/download`, { params: { file } })
             .then(({ data }) => resolve(data.attributes.url))
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/getFileUploadUrl.ts
+++ b/resources/scripts/api/server/files/getFileUploadUrl.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string): Promise<string> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/files/upload`)
+        http.get(`/api/client/services/${uuid}/files/upload`)
             .then(({ data }) => resolve(data.attributes.url))
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/loadDirectory.ts
+++ b/resources/scripts/api/server/files/loadDirectory.ts
@@ -17,7 +17,7 @@ export interface FileObject {
 }
 
 export default async (uuid: string, directory?: string): Promise<FileObject[]> => {
-    const { data } = await http.get(`/api/client/servers/${uuid}/files/list`, {
+    const { data } = await http.get(`/api/client/services/${uuid}/files/list`, {
         params: { directory: directory ?? '/' },
     });
 

--- a/resources/scripts/api/server/files/renameFiles.ts
+++ b/resources/scripts/api/server/files/renameFiles.ts
@@ -7,7 +7,7 @@ interface Data {
 
 export default (uuid: string, directory: string, files: Data[]): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.put(`/api/client/servers/${uuid}/files/rename`, { root: directory, files })
+        http.put(`/api/client/services/${uuid}/files/rename`, { root: directory, files })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/files/saveFileContents.ts
+++ b/resources/scripts/api/server/files/saveFileContents.ts
@@ -1,7 +1,7 @@
 import http from '@/api/http';
 
 export default async (uuid: string, file: string, content: string): Promise<void> => {
-    await http.post(`/api/client/servers/${uuid}/files/write`, content, {
+    await http.post(`/api/client/services/${uuid}/files/write`, content, {
         params: { file },
         headers: {
             'Content-Type': 'text/plain',

--- a/resources/scripts/api/server/getServer.ts
+++ b/resources/scripts/api/server/getServer.ts
@@ -74,7 +74,7 @@ export const rawDataToServerObject = ({ attributes: data }: FractalResponseData)
 
 export default (uuid: string): Promise<[Server, string[]]> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}`)
+        http.get(`/api/client/services/${uuid}`)
             .then(({ data }) =>
                 resolve([
                     rawDataToServerObject(data),

--- a/resources/scripts/api/server/getServerResourceUsage.ts
+++ b/resources/scripts/api/server/getServerResourceUsage.ts
@@ -15,7 +15,7 @@ export interface ServerStats {
 
 export default (server: string): Promise<ServerStats> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${server}/resources`)
+        http.get(`/api/client/services/${server}/resources`)
             .then(({ data: { attributes } }) =>
                 resolve({
                     status: attributes.current_state,

--- a/resources/scripts/api/server/getWebsocketToken.ts
+++ b/resources/scripts/api/server/getWebsocketToken.ts
@@ -7,7 +7,7 @@ interface Response {
 
 export default (server: string): Promise<Response> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${server}/websocket`)
+        http.get(`/api/client/services/${server}/websocket`)
             .then(({ data }) =>
                 resolve({
                     token: data.data.token,

--- a/resources/scripts/api/server/network/createServerAllocation.ts
+++ b/resources/scripts/api/server/network/createServerAllocation.ts
@@ -3,7 +3,7 @@ import http from '@/api/http';
 import { rawDataToServerAllocation } from '@/api/transformers';
 
 export default async (uuid: string): Promise<Allocation> => {
-    const { data } = await http.post(`/api/client/servers/${uuid}/network/allocations`);
+    const { data } = await http.post(`/api/client/services/${uuid}/network/allocations`);
 
     return rawDataToServerAllocation(data);
 };

--- a/resources/scripts/api/server/network/deleteServerAllocation.ts
+++ b/resources/scripts/api/server/network/deleteServerAllocation.ts
@@ -2,4 +2,4 @@ import { Allocation } from '@/api/server/getServer';
 import http from '@/api/http';
 
 export default async (uuid: string, id: number): Promise<Allocation> =>
-    await http.delete(`/api/client/servers/${uuid}/network/allocations/${id}`);
+    await http.delete(`/api/client/services/${uuid}/network/allocations/${id}`);

--- a/resources/scripts/api/server/network/setPrimaryServerAllocation.ts
+++ b/resources/scripts/api/server/network/setPrimaryServerAllocation.ts
@@ -3,7 +3,7 @@ import http from '@/api/http';
 import { rawDataToServerAllocation } from '@/api/transformers';
 
 export default async (uuid: string, id: number): Promise<Allocation> => {
-    const { data } = await http.post(`/api/client/servers/${uuid}/network/allocations/${id}/primary`);
+    const { data } = await http.post(`/api/client/services/${uuid}/network/allocations/${id}/primary`);
 
     return rawDataToServerAllocation(data);
 };

--- a/resources/scripts/api/server/network/setServerAllocationNotes.ts
+++ b/resources/scripts/api/server/network/setServerAllocationNotes.ts
@@ -3,7 +3,7 @@ import http from '@/api/http';
 import { rawDataToServerAllocation } from '@/api/transformers';
 
 export default async (uuid: string, id: number, notes: string | null): Promise<Allocation> => {
-    const { data } = await http.post(`/api/client/servers/${uuid}/network/allocations/${id}`, { notes });
+    const { data } = await http.post(`/api/client/services/${uuid}/network/allocations/${id}`, { notes });
 
     return rawDataToServerAllocation(data);
 };

--- a/resources/scripts/api/server/reinstallServer.ts
+++ b/resources/scripts/api/server/reinstallServer.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/settings/reinstall`)
+        http.post(`/api/client/services/${uuid}/settings/reinstall`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/renameServer.ts
+++ b/resources/scripts/api/server/renameServer.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, name: string, description?: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/settings/rename`, { name, description })
+        http.post(`/api/client/services/${uuid}/settings/rename`, { name, description })
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/schedules/createOrUpdateSchedule.ts
+++ b/resources/scripts/api/server/schedules/createOrUpdateSchedule.ts
@@ -4,7 +4,7 @@ import http from '@/api/http';
 type Data = Pick<Schedule, 'cron' | 'name' | 'onlyWhenOnline' | 'isActive'> & { id?: number };
 
 export default async (uuid: string, schedule: Data): Promise<Schedule> => {
-    const { data } = await http.post(`/api/client/servers/${uuid}/schedules${schedule.id ? `/${schedule.id}` : ''}`, {
+    const { data } = await http.post(`/api/client/services/${uuid}/schedules${schedule.id ? `/${schedule.id}` : ''}`, {
         is_active: schedule.isActive,
         only_when_online: schedule.onlyWhenOnline,
         name: schedule.name,

--- a/resources/scripts/api/server/schedules/createOrUpdateScheduleTask.ts
+++ b/resources/scripts/api/server/schedules/createOrUpdateScheduleTask.ts
@@ -10,7 +10,7 @@ interface Data {
 
 export default async (uuid: string, schedule: number, task: number | undefined, data: Data): Promise<Task> => {
     const { data: response } = await http.post(
-        `/api/client/servers/${uuid}/schedules/${schedule}/tasks${task ? `/${task}` : ''}`,
+        `/api/client/services/${uuid}/schedules/${schedule}/tasks${task ? `/${task}` : ''}`,
         {
             action: data.action,
             payload: data.payload,

--- a/resources/scripts/api/server/schedules/deleteSchedule.ts
+++ b/resources/scripts/api/server/schedules/deleteSchedule.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, schedule: number): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.delete(`/api/client/servers/${uuid}/schedules/${schedule}`)
+        http.delete(`/api/client/services/${uuid}/schedules/${schedule}`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/schedules/deleteScheduleTask.ts
+++ b/resources/scripts/api/server/schedules/deleteScheduleTask.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, scheduleId: number, taskId: number): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.delete(`/api/client/servers/${uuid}/schedules/${scheduleId}/tasks/${taskId}`)
+        http.delete(`/api/client/services/${uuid}/schedules/${scheduleId}/tasks/${taskId}`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/schedules/getServerSchedule.ts
+++ b/resources/scripts/api/server/schedules/getServerSchedule.ts
@@ -3,7 +3,7 @@ import { rawDataToServerSchedule, Schedule } from '@/api/server/schedules/getSer
 
 export default (uuid: string, schedule: number): Promise<Schedule> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/schedules/${schedule}`, {
+        http.get(`/api/client/services/${uuid}/schedules/${schedule}`, {
             params: {
                 include: ['tasks'],
             },

--- a/resources/scripts/api/server/schedules/getServerSchedules.ts
+++ b/resources/scripts/api/server/schedules/getServerSchedules.ts
@@ -67,7 +67,7 @@ export const rawDataToServerSchedule = (data: any): Schedule => ({
 });
 
 export default async (uuid: string): Promise<Schedule[]> => {
-    const { data } = await http.get(`/api/client/servers/${uuid}/schedules`, {
+    const { data } = await http.get(`/api/client/services/${uuid}/schedules`, {
         params: {
             include: ['tasks'],
         },

--- a/resources/scripts/api/server/schedules/triggerScheduleExecution.ts
+++ b/resources/scripts/api/server/schedules/triggerScheduleExecution.ts
@@ -1,4 +1,4 @@
 import http from '@/api/http';
 
 export default async (server: string, schedule: number): Promise<void> =>
-    await http.post(`/api/client/servers/${server}/schedules/${schedule}/execute`);
+    await http.post(`/api/client/services/${server}/schedules/${schedule}/execute`);

--- a/resources/scripts/api/server/setSelectedDockerImage.ts
+++ b/resources/scripts/api/server/setSelectedDockerImage.ts
@@ -1,5 +1,5 @@
 import http from '@/api/http';
 
 export default async (uuid: string, image: string): Promise<void> => {
-    await http.put(`/api/client/servers/${uuid}/settings/docker-image`, { docker_image: image });
+    await http.put(`/api/client/services/${uuid}/settings/docker-image`, { docker_image: image });
 };

--- a/resources/scripts/api/server/updateStartupVariable.ts
+++ b/resources/scripts/api/server/updateStartupVariable.ts
@@ -3,7 +3,7 @@ import { ServerEggVariable } from '@/api/server/types';
 import { rawDataToServerEggVariable } from '@/api/transformers';
 
 export default async (uuid: string, key: string, value: string): Promise<[ServerEggVariable, string]> => {
-    const { data } = await http.put(`/api/client/servers/${uuid}/startup/variable`, { key, value });
+    const { data } = await http.put(`/api/client/services/${uuid}/startup/variable`, { key, value });
 
     return [rawDataToServerEggVariable(data), data.meta.startup_command];
 };

--- a/resources/scripts/api/server/users/createOrUpdateSubuser.ts
+++ b/resources/scripts/api/server/users/createOrUpdateSubuser.ts
@@ -9,7 +9,7 @@ interface Params {
 
 export default (uuid: string, params: Params, subuser?: Subuser): Promise<Subuser> => {
     return new Promise((resolve, reject) => {
-        http.post(`/api/client/servers/${uuid}/users${subuser ? `/${subuser.uuid}` : ''}`, {
+        http.post(`/api/client/services/${uuid}/users${subuser ? `/${subuser.uuid}` : ''}`, {
             ...params,
         })
             .then((data) => resolve(rawDataToServerSubuser(data.data)))

--- a/resources/scripts/api/server/users/deleteSubuser.ts
+++ b/resources/scripts/api/server/users/deleteSubuser.ts
@@ -2,7 +2,7 @@ import http from '@/api/http';
 
 export default (uuid: string, userId: string): Promise<void> => {
     return new Promise((resolve, reject) => {
-        http.delete(`/api/client/servers/${uuid}/users/${userId}`)
+        http.delete(`/api/client/services/${uuid}/users/${userId}`)
             .then(() => resolve())
             .catch(reject);
     });

--- a/resources/scripts/api/server/users/getServerSubusers.ts
+++ b/resources/scripts/api/server/users/getServerSubusers.ts
@@ -14,7 +14,7 @@ export const rawDataToServerSubuser = (data: FractalResponseData): Subuser => ({
 
 export default (uuid: string): Promise<Subuser[]> => {
     return new Promise((resolve, reject) => {
-        http.get(`/api/client/servers/${uuid}/users`)
+        http.get(`/api/client/services/${uuid}/users`)
             .then(({ data }) => resolve((data.data || []).map(rawDataToServerSubuser)))
             .catch(reject);
     });

--- a/resources/scripts/api/swr/getServerAllocations.ts
+++ b/resources/scripts/api/swr/getServerAllocations.ts
@@ -10,7 +10,7 @@ export default () => {
     return useSWR<Allocation[]>(
         ['server:allocations', uuid],
         async () => {
-            const { data } = await http.get(`/api/client/servers/${uuid}/network/allocations`);
+            const { data } = await http.get(`/api/client/services/${uuid}/network/allocations`);
 
             return (data.data || []).map(rawDataToServerAllocation);
         },

--- a/resources/scripts/api/swr/getServerBackups.ts
+++ b/resources/scripts/api/swr/getServerBackups.ts
@@ -19,7 +19,7 @@ export default () => {
     const uuid = ServerContext.useStoreState((state) => state.server.data!.uuid);
 
     return useSWR<BackupResponse>(['server:backups', uuid, page], async () => {
-        const { data } = await http.get(`/api/client/servers/${uuid}/backups`, { params: { page } });
+        const { data } = await http.get(`/api/client/services/${uuid}/backups`, { params: { page } });
 
         return {
             items: (data.data || []).map(rawDataToServerBackup),

--- a/resources/scripts/api/swr/getServerStartup.ts
+++ b/resources/scripts/api/swr/getServerStartup.ts
@@ -13,7 +13,7 @@ export default (uuid: string, initialData?: Response | null, config?: ConfigInte
     useSWR(
         [uuid, '/startup'],
         async (): Promise<Response> => {
-            const { data } = await http.get(`/api/client/servers/${uuid}/startup`);
+            const { data } = await http.get(`/api/client/services/${uuid}/startup`);
 
             const variables = ((data as FractalResponseList).data || []).map(rawDataToServerEggVariable);
 

--- a/resources/scripts/components/App.tsx
+++ b/resources/scripts/components/App.tsx
@@ -69,7 +69,7 @@ const App = () => {
                                     <AuthenticationRouter />
                                 </Spinner.Suspense>
                             </Route>
-                            <AuthenticatedRoute path={'/server/:id'}>
+                            <AuthenticatedRoute path={'/services/:id'}>
                                 <Spinner.Suspense>
                                     <ServerContext.Provider>
                                         <ServerRouter />

--- a/resources/scripts/components/dashboard/DashboardContainer.tsx
+++ b/resources/scripts/components/dashboard/DashboardContainer.tsx
@@ -25,7 +25,7 @@ export default () => {
     const [showOnlyAdmin, setShowOnlyAdmin] = usePersistedState(`${uuid}:show_all_servers`, false);
 
     const { data: servers, error } = useSWR<PaginatedResult<Server>>(
-        ['/api/client/servers', showOnlyAdmin && rootAdmin, page],
+        ['/api/client/services', showOnlyAdmin && rootAdmin, page],
         () => getServers({ page, type: showOnlyAdmin && rootAdmin ? 'admin' : undefined })
     );
 

--- a/resources/scripts/components/dashboard/ServerRow.tsx
+++ b/resources/scripts/components/dashboard/ServerRow.tsx
@@ -89,7 +89,7 @@ export default ({ server, className }: { server: Server; className?: string }) =
     const cpuLimit = server.limits.cpu !== 0 ? server.limits.cpu + ' %' : 'Unlimited';
 
     return (
-        <StatusIndicatorBox as={Link} to={`/server/${server.id}`} className={className} $status={stats?.status}>
+        <StatusIndicatorBox as={Link} to={`/services/${server.id}`} className={className} $status={stats?.status}>
             <div css={tw`flex items-center col-span-12 sm:col-span-5 lg:col-span-6`}>
                 <div className={'icon mr-4'}>
                     <FontAwesomeIcon icon={faServer} />

--- a/resources/scripts/components/dashboard/search/SearchModal.tsx
+++ b/resources/scripts/components/dashboard/search/SearchModal.tsx
@@ -103,7 +103,7 @@ export default ({ ...props }: Props) => {
                             {servers.map((server) => (
                                 <ServerResult
                                     key={server.uuid}
-                                    to={`/server/${server.id}`}
+                                    to={`/services/${server.id}`}
                                     onClick={() => props.onDismissed()}
                                 >
                                     <div css={tw`flex-1 mr-4`}>

--- a/resources/scripts/components/server/WebsocketHandler.tsx
+++ b/resources/scripts/components/server/WebsocketHandler.tsx
@@ -48,7 +48,7 @@ export default () => {
         socket.on('token expired', () => updateToken(uuid, socket));
         socket.on('jwt error', (error: string) => {
             setConnectionState(false);
-            console.warn('JWT validation error from wings:', error);
+            console.warn('JWT validation error from daemon:', error);
 
             if (reconnectErrors.find((v) => error.toLowerCase().indexOf(v) >= 0)) {
                 updateToken(uuid, socket);

--- a/resources/scripts/components/server/backups/BackupContextMenu.tsx
+++ b/resources/scripts/components/server/backups/BackupContextMenu.tsx
@@ -96,7 +96,7 @@ export default ({ backup }: Props) => {
             return setModal('unlock');
         }
 
-        http.post(`/api/client/servers/${uuid}/backups/${backup.uuid}/lock`)
+        http.post(`/api/client/services/${uuid}/backups/${backup.uuid}/lock`)
             .then(() =>
                 mutate(
                     (data) => ({

--- a/resources/scripts/components/server/features/PIDLimitModalFeature.tsx
+++ b/resources/scripts/components/server/features/PIDLimitModalFeature.tsx
@@ -64,12 +64,12 @@ const PIDLimitModalFeature = () => {
                     </div>
                     <p css={tw`mt-4`}>This server has reached the maximum process or memory limit.</p>
                     <p css={tw`mt-4`}>
-                        Increasing <code css={tw`font-mono bg-neutral-900`}>container_pid_limit</code> in the wings
+                        Increasing <code css={tw`font-mono bg-neutral-900`}>container_pid_limit</code> in the daemon
                         configuration, <code css={tw`font-mono bg-neutral-900`}>config.yml</code>, might help resolve
                         this issue.
                     </p>
                     <p css={tw`mt-4`}>
-                        <b>Note: Wings must be restarted for the configuration file changes to take effect</b>
+                        <b>Note: Daemon must be restarted for the configuration file changes to take effect</b>
                     </p>
                     <div css={tw`mt-8 sm:flex items-center justify-end`}>
                         <Button onClick={() => setVisible(false)} css={tw`w-full sm:w-auto border-transparent`}>

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -66,7 +66,7 @@ export default () => {
             .then((content) => saveFileContents(uuid, name || hashToPath(hash), content))
             .then(() => {
                 if (name) {
-                    history.push(`/server/${id}/files/edit#/${encodePathSegments(name)}`);
+                    history.push(`/services/${id}/files/edit#/${encodePathSegments(name)}`);
                     return;
                 }
 

--- a/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
+++ b/resources/scripts/components/server/files/FileManagerBreadcrumbs.tsx
@@ -40,7 +40,7 @@ export default ({ renderLeft, withinFileEditor, isNewFile }: Props) => {
     return (
         <div css={tw`flex flex-grow-0 items-center text-sm text-neutral-500 overflow-x-hidden`}>
             {renderLeft || <div css={tw`w-12`} />}/<span css={tw`px-1 text-neutral-300`}>home</span>/
-            <NavLink to={`/server/${id}/files`} css={tw`px-1 text-neutral-200 no-underline hover:text-neutral-100`}>
+            <NavLink to={`/services/${id}/files`} css={tw`px-1 text-neutral-200 no-underline hover:text-neutral-100`}>
                 container
             </NavLink>
             /
@@ -48,7 +48,7 @@ export default ({ renderLeft, withinFileEditor, isNewFile }: Props) => {
                 crumb.path ? (
                     <React.Fragment key={index}>
                         <NavLink
-                            to={`/server/${id}/files#${encodePathSegments(crumb.path)}`}
+                            to={`/services/${id}/files#${encodePathSegments(crumb.path)}`}
                             css={tw`px-1 text-neutral-200 no-underline hover:text-neutral-100`}
                         >
                             {crumb.name}

--- a/resources/scripts/components/server/files/FileManagerContainer.tsx
+++ b/resources/scripts/components/server/files/FileManagerContainer.tsx
@@ -78,7 +78,7 @@ export default () => {
                             <FileManagerStatus />
                             <NewDirectoryButton />
                             <UploadButton />
-                            <NavLink to={`/server/${id}/files/new${window.location.hash}`}>
+                            <NavLink to={`/services/${id}/files/new${window.location.hash}`}>
                                 <Button>New File</Button>
                             </NavLink>
                         </div>

--- a/resources/scripts/components/server/schedules/ScheduleEditContainer.tsx
+++ b/resources/scripts/components/server/schedules/ScheduleEditContainer.tsx
@@ -157,7 +157,7 @@ export default () => {
                         <Can action={'schedule.delete'}>
                             <DeleteScheduleButton
                                 scheduleId={schedule.id}
-                                onDeleted={() => history.push(`/server/${id}/schedules`)}
+                                onDeleted={() => history.push(`/services/${id}/schedules`)}
                             />
                         </Can>
                         {schedule.tasks.length > 0 && (

--- a/resources/scripts/routers/ServerRouter.tsx
+++ b/resources/scripts/routers/ServerRouter.tsx
@@ -93,7 +93,7 @@ export default () => {
                                     )}
                                 {rootAdmin && (
                                     // eslint-disable-next-line react/jsx-no-target-blank
-                                    <a href={`/admin/servers/view/${serverId}`} target={'_blank'}>
+                                    <a href={`/admin/services/view/${serverId}`} target={'_blank'}>
                                         <FontAwesomeIcon icon={faExternalLinkAlt} />
                                     </a>
                                 )}
@@ -103,7 +103,7 @@ export default () => {
                     <InstallListener />
                     <TransferListener />
                     <WebsocketHandler />
-                    {inConflictState && (!rootAdmin || (rootAdmin && !location.pathname.endsWith(`/server/${id}`))) ? (
+                    {inConflictState && (!rootAdmin || (rootAdmin && !location.pathname.endsWith(`/services/${id}`))) ? (
                         <ConflictStateRenderer />
                     ) : (
                         <ErrorBoundary>

--- a/resources/scripts/routers/routes.ts
+++ b/resources/scripts/routers/routes.ts
@@ -38,7 +38,7 @@ interface ServerRouteDefinition extends RouteDefinition {
 interface Routes {
     // All of the routes available under "/account"
     account: RouteDefinition[];
-    // All of the routes available under "/server/:id"
+    // All of the routes available under "/services/:id"
     server: ServerRouteDefinition[];
 }
 

--- a/resources/views/admin/servers/index.blade.php
+++ b/resources/views/admin/servers/index.blade.php
@@ -61,7 +61,7 @@
                                     @endif
                                 </td>
                                 <td class="text-center">
-                                    <a class="btn btn-xs btn-default" href="/server/{{ $server->uuidShort }}"><i class="fa fa-wrench"></i></a>
+                                    <a class="btn btn-xs btn-default" href="/services/{{ $server->uuidShort }}"><i class="fa fa-wrench"></i></a>
                                 </td>
                             </tr>
                         @endforeach

--- a/resources/views/admin/servers/partials/navigation.blade.php
+++ b/resources/views/admin/servers/partials/navigation.blade.php
@@ -32,7 +32,7 @@
                     <a href="{{ route('admin.servers.view.delete', $server->id) }}">Delete</a>
                 </li>
                 <li class="tab-success">
-                    <a href="/server/{{ $server->uuidShort }}" target="_blank"><i class="fa fa-external-link"></i></a>
+                    <a href="/services/{{ $server->uuidShort }}" target="_blank"><i class="fa fa-external-link"></i></a>
                 </li>
             </ul>
         </div>

--- a/resources/views/admin/servers/view/database.blade.php
+++ b/resources/views/admin/servers/view/database.blade.php
@@ -19,7 +19,7 @@
 <div class="row">
     <div class="col-sm-7">
         <div class="alert alert-info">
-            Database passwords can be viewed when <a href="/server/{{ $server->uuidShort }}/databases">visiting this server</a> on the front-end.
+            Database passwords can be viewed when <a href="/services/{{ $server->uuidShort }}/databases">visiting this server</a> on the front-end.
         </div>
         <div class="box box-primary">
             <div class="box-header with-border">
@@ -120,7 +120,7 @@
         }, function () {
             $.ajax({
                 method: 'DELETE',
-                url: '/admin/servers/view/{{ $server->id }}/database/' + self.data('id') + '/delete',
+                url: '/admin/services/view/{{ $server->id }}/database/' + self.data('id') + '/delete',
                 headers: { 'X-CSRF-TOKEN': $('meta[name="_token"]').attr('content') },
             }).done(function () {
                 self.parent().parent().slideUp();
@@ -141,7 +141,7 @@
         $(this).addClass('disabled').find('i').addClass('fa-spin');
         $.ajax({
             type: 'PATCH',
-            url: '/admin/servers/view/{{ $server->id }}/database',
+            url: '/admin/services/view/{{ $server->id }}/database',
             headers: { 'X-CSRF-TOKEN': $('meta[name="_token"]').attr('content') },
             data: { database: $(this).data('id') },
         }).done(function (data) {

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -101,10 +101,10 @@ Route::group(['prefix' => 'users'], function () {
 | Server Controller Routes
 |--------------------------------------------------------------------------
 |
-| Endpoint: /admin/servers
+| Endpoint: /admin/services
 |
 */
-Route::group(['prefix' => 'servers'], function () {
+Route::group(['prefix' => 'services'], function () {
     Route::get('/', [Admin\Servers\ServerController::class, 'index'])->name('admin.servers');
     Route::get('/new', [Admin\Servers\CreateServerController::class, 'index'])->name('admin.servers.new');
     Route::get('/view/{server:id}', [Admin\Servers\ServerViewController::class, 'index'])->name('admin.servers.view');

--- a/routes/api-application.php
+++ b/routes/api-application.php
@@ -72,10 +72,10 @@ Route::group(['prefix' => '/locations'], function () {
 | Server Controller Routes
 |--------------------------------------------------------------------------
 |
-| Endpoint: /api/application/servers
+| Endpoint: /api/application/services
 |
 */
-Route::group(['prefix' => '/servers'], function () {
+Route::group(['prefix' => '/services'], function () {
     Route::get('/', [Application\Servers\ServerController::class, 'index'])->name('api.application.servers');
     Route::get('/{server:id}', [Application\Servers\ServerController::class, 'view'])->name('api.application.servers.view');
     Route::get('/external/{external_id}', [Application\Servers\ExternalServerController::class, 'index'])->name('api.application.servers.external');

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -48,11 +48,11 @@ Route::prefix('/account')->middleware(AccountSubject::class)->group(function () 
 | Client Control API
 |--------------------------------------------------------------------------
 |
-| Endpoint: /api/client/servers/{server}
+| Endpoint: /api/client/services/{service}
 |
 */
 Route::group([
-    'prefix' => '/servers/{server}',
+    'prefix' => '/services/{service}',
     'middleware' => [
         ServerSubject::class,
         AuthenticateServerAccess::class,

--- a/routes/api-remote.php
+++ b/routes/api-remote.php
@@ -1,28 +1,3 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use Pterodactyl\Http\Controllers\Api\Remote;
-
-// Routes for the Wings daemon.
-Route::post('/sftp/auth', Remote\SftpAuthenticationController::class);
-
-Route::get('/servers', [Remote\Servers\ServerDetailsController::class, 'list']);
-Route::post('/servers/reset', [Remote\Servers\ServerDetailsController::class, 'resetState']);
-Route::post('/activity', Remote\ActivityProcessingController::class);
-
-Route::group(['prefix' => '/servers/{uuid}'], function () {
-    Route::get('/', Remote\Servers\ServerDetailsController::class);
-    Route::get('/install', [Remote\Servers\ServerInstallController::class, 'index']);
-    Route::post('/install', [Remote\Servers\ServerInstallController::class, 'store']);
-
-    Route::get('/transfer/failure', [Remote\Servers\ServerTransferController::class, 'failure']);
-    Route::get('/transfer/success', [Remote\Servers\ServerTransferController::class, 'success']);
-    Route::post('/transfer/failure', [Remote\Servers\ServerTransferController::class, 'failure']);
-    Route::post('/transfer/success', [Remote\Servers\ServerTransferController::class, 'success']);
-});
-
-Route::group(['prefix' => '/backups'], function () {
-    Route::get('/{backup}', Remote\Backups\BackupRemoteUploadController::class);
-    Route::post('/{backup}', [Remote\Backups\BackupStatusController::class, 'index']);
-    Route::post('/{backup}/restore', [Remote\Backups\BackupStatusController::class, 'restore']);
-});
+// Wings integration removed.

--- a/tests/Integration/Api/Client/ClientApiIntegrationTestCase.php
+++ b/tests/Integration/Api/Client/ClientApiIntegrationTestCase.php
@@ -58,19 +58,19 @@ abstract class ClientApiIntegrationTestCase extends IntegrationTestCase
     {
         switch (get_class($model)) {
             case Server::class:
-                $link = "/api/client/servers/$model->uuid";
+                $link = "/api/client/services/$model->uuid";
                 break;
             case Schedule::class:
-                $link = "/api/client/servers/{$model->server->uuid}/schedules/$model->id";
+                $link = "/api/client/services/{$model->server->uuid}/schedules/$model->id";
                 break;
             case Task::class:
-                $link = "/api/client/servers/{$model->schedule->server->uuid}/schedules/{$model->schedule->id}/tasks/$model->id";
+                $link = "/api/client/services/{$model->schedule->server->uuid}/schedules/{$model->schedule->id}/tasks/$model->id";
                 break;
             case Allocation::class:
-                $link = "/api/client/servers/{$model->server->uuid}/network/allocations/$model->id";
+                $link = "/api/client/services/{$model->server->uuid}/network/allocations/$model->id";
                 break;
             case Backup::class:
-                $link = "/api/client/servers/{$model->server->uuid}/backups/$model->uuid";
+                $link = "/api/client/services/{$model->server->uuid}/backups/$model->uuid";
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Cannot create link for Model of type %s', class_basename($model)));

--- a/tests/Integration/Api/Client/Server/CommandControllerTest.php
+++ b/tests/Integration/Api/Client/Server/CommandControllerTest.php
@@ -22,7 +22,7 @@ class CommandControllerTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount();
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/command", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/command", [
             'command' => '',
         ]);
 
@@ -38,7 +38,7 @@ class CommandControllerTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_WEBSOCKET_CONNECT]);
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/command", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/command", [
             'command' => 'say Test',
         ]);
 
@@ -59,7 +59,7 @@ class CommandControllerTest extends ClientApiIntegrationTestCase
 
         $mock->expects('send')->with('say Test')->andReturn(new GuzzleResponse());
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/command", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/command", [
             'command' => 'say Test',
         ]);
 
@@ -81,7 +81,7 @@ class CommandControllerTest extends ClientApiIntegrationTestCase
             )
         );
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/command", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/command", [
             'command' => 'say Test',
         ]);
 

--- a/tests/Integration/Api/Client/Server/PowerControllerTest.php
+++ b/tests/Integration/Api/Client/Server/PowerControllerTest.php
@@ -23,7 +23,7 @@ class PowerControllerTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount($permissions);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/power", ['signal' => $action])
+            ->postJson("/api/client/services/$server->uuid/power", ['signal' => $action])
             ->assertStatus(Response::HTTP_FORBIDDEN);
     }
 
@@ -34,7 +34,7 @@ class PowerControllerTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount();
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/power", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/power", [
             'signal' => 'invalid',
         ]);
 
@@ -65,7 +65,7 @@ class PowerControllerTest extends ClientApiIntegrationTestCase
             ->with(trim($action));
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/power", ['signal' => $action])
+            ->postJson("/api/client/services/$server->uuid/power", ['signal' => $action])
             ->assertStatus(Response::HTTP_NO_CONTENT);
     }
 

--- a/tests/Integration/Api/Client/Server/ResourceUtilizationControllerTest.php
+++ b/tests/Integration/Api/Client/Server/ResourceUtilizationControllerTest.php
@@ -22,7 +22,7 @@ class ResourceUtilizationControllerTest extends ClientApiIntegrationTestCase
             return $server->uuid === $value->uuid;
         }))->andReturnSelf()->getMock()->expects('getDetails')->andReturns([]);
 
-        $response = $this->actingAs($user)->getJson("/api/client/servers/$server->uuid/resources");
+        $response = $this->actingAs($user)->getJson("/api/client/services/$server->uuid/resources");
 
         $response->assertOk();
         $response->assertJson([

--- a/tests/Integration/Api/Client/Server/Schedule/CreateServerScheduleTest.php
+++ b/tests/Integration/Api/Client/Server/Schedule/CreateServerScheduleTest.php
@@ -18,7 +18,7 @@ class CreateServerScheduleTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount($permissions);
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/schedules", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/schedules", [
             'name' => 'Test Schedule',
             'is_active' => false,
             'minute' => '0',
@@ -54,7 +54,7 @@ class CreateServerScheduleTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount();
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/schedules", []);
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/schedules", []);
 
         $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
         foreach (['name', 'minute', 'hour', 'day_of_month', 'day_of_week'] as $i => $field) {
@@ -64,7 +64,7 @@ class CreateServerScheduleTest extends ClientApiIntegrationTestCase
         }
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/schedules", [
+            ->postJson("/api/client/services/$server->uuid/schedules", [
                 'name' => 'Testing',
                 'is_active' => 'no',
                 'minute' => '*',
@@ -85,7 +85,7 @@ class CreateServerScheduleTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_SCHEDULE_UPDATE]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/schedules", [])
+            ->postJson("/api/client/services/$server->uuid/schedules", [])
             ->assertForbidden();
     }
 

--- a/tests/Integration/Api/Client/Server/Schedule/DeleteServerScheduleTest.php
+++ b/tests/Integration/Api/Client/Server/Schedule/DeleteServerScheduleTest.php
@@ -23,7 +23,7 @@ class DeleteServerScheduleTest extends ClientApiIntegrationTestCase
         $task = Task::factory()->create(['schedule_id' => $schedule->id]);
 
         $this->actingAs($user)
-            ->deleteJson("/api/client/servers/$server->uuid/schedules/$schedule->id")
+            ->deleteJson("/api/client/services/$server->uuid/schedules/$schedule->id")
             ->assertStatus(Response::HTTP_NO_CONTENT);
 
         $this->assertDatabaseMissing('schedules', ['id' => $schedule->id]);
@@ -38,7 +38,7 @@ class DeleteServerScheduleTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount();
 
         $this->actingAs($user)
-            ->deleteJson("/api/client/servers/$server->uuid/schedules/123456789")
+            ->deleteJson("/api/client/services/$server->uuid/schedules/123456789")
             ->assertStatus(Response::HTTP_NOT_FOUND);
     }
 
@@ -54,7 +54,7 @@ class DeleteServerScheduleTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server2->id]);
 
         $this->actingAs($user)
-            ->deleteJson("/api/client/servers/$server->uuid/schedules/$schedule->id")
+            ->deleteJson("/api/client/services/$server->uuid/schedules/$schedule->id")
             ->assertStatus(Response::HTTP_NOT_FOUND);
 
         $this->assertDatabaseHas('schedules', ['id' => $schedule->id]);
@@ -71,7 +71,7 @@ class DeleteServerScheduleTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server->id]);
 
         $this->actingAs($user)
-            ->deleteJson("/api/client/servers/$server->uuid/schedules/$schedule->id")
+            ->deleteJson("/api/client/services/$server->uuid/schedules/$schedule->id")
             ->assertStatus(Response::HTTP_FORBIDDEN);
 
         $this->assertDatabaseHas('schedules', ['id' => $schedule->id]);

--- a/tests/Integration/Api/Client/Server/Schedule/GetServerSchedulesTest.php
+++ b/tests/Integration/Api/Client/Server/Schedule/GetServerSchedulesTest.php
@@ -37,8 +37,8 @@ class GetServerSchedulesTest extends ClientApiIntegrationTestCase
         $response = $this->actingAs($user)
             ->getJson(
                 $individual
-                    ? "/api/client/servers/$server->uuid/schedules/$schedule->id"
-                    : "/api/client/servers/$server->uuid/schedules"
+                    ? "/api/client/services/$server->uuid/schedules/$schedule->id"
+                    : "/api/client/services/$server->uuid/schedules"
             )
             ->assertOk();
 
@@ -67,7 +67,7 @@ class GetServerSchedulesTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server2->id]);
 
         $this->actingAs($user)
-            ->getJson("/api/client/servers/$server->uuid/schedules/$schedule->id")
+            ->getJson("/api/client/services/$server->uuid/schedules/$schedule->id")
             ->assertNotFound();
     }
 
@@ -79,13 +79,13 @@ class GetServerSchedulesTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_WEBSOCKET_CONNECT]);
 
         $this->actingAs($user)
-            ->getJson("/api/client/servers/$server->uuid/schedules")
+            ->getJson("/api/client/services/$server->uuid/schedules")
             ->assertForbidden();
 
         $schedule = Schedule::factory()->create(['server_id' => $server->id]);
 
         $this->actingAs($user)
-            ->getJson("/api/client/servers/$server->uuid/schedules/$schedule->id")
+            ->getJson("/api/client/services/$server->uuid/schedules/$schedule->id")
             ->assertForbidden();
     }
 

--- a/tests/Integration/Api/Client/Server/Schedule/UpdateServerScheduleTest.php
+++ b/tests/Integration/Api/Client/Server/Schedule/UpdateServerScheduleTest.php
@@ -36,7 +36,7 @@ class UpdateServerScheduleTest extends ClientApiIntegrationTestCase
         $expected = Utilities::getScheduleNextRunDate('5', '*', '*', '*', '*');
 
         $response = $this->actingAs($user)
-            ->postJson("/api/client/servers/{$server->uuid}/schedules/{$schedule->id}", $this->updateData);
+            ->postJson("/api/client/services/{$server->uuid}/schedules/{$schedule->id}", $this->updateData);
 
         $schedule = $schedule->refresh();
 
@@ -60,7 +60,7 @@ class UpdateServerScheduleTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server2->id]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/{$server->uuid}/schedules/{$schedule->id}")
+            ->postJson("/api/client/services/{$server->uuid}/schedules/{$schedule->id}")
             ->assertNotFound();
     }
 
@@ -75,7 +75,7 @@ class UpdateServerScheduleTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server->id]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/{$server->uuid}/schedules/{$schedule->id}")
+            ->postJson("/api/client/services/{$server->uuid}/schedules/{$schedule->id}")
             ->assertForbidden();
     }
 
@@ -100,7 +100,7 @@ class UpdateServerScheduleTest extends ClientApiIntegrationTestCase
         $this->assertTrue($schedule->is_processing);
 
         $response = $this->actingAs($user)
-            ->postJson("/api/client/servers/{$server->uuid}/schedules/{$schedule->id}", $this->updateData);
+            ->postJson("/api/client/services/{$server->uuid}/schedules/{$schedule->id}", $this->updateData);
 
         $schedule = $schedule->refresh();
 

--- a/tests/Integration/Api/Client/Server/ScheduleTask/CreateServerScheduleTaskTest.php
+++ b/tests/Integration/Api/Client/Server/ScheduleTask/CreateServerScheduleTaskTest.php
@@ -150,7 +150,7 @@ class CreateServerScheduleTaskTest extends ClientApiIntegrationTestCase
         $schedule = Schedule::factory()->create(['server_id' => $server2->id]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/schedules/$schedule->id/tasks")
+            ->postJson("/api/client/services/$server->uuid/schedules/$schedule->id/tasks")
             ->assertNotFound();
     }
 

--- a/tests/Integration/Api/Client/Server/ScheduleTask/DeleteScheduleTaskTest.php
+++ b/tests/Integration/Api/Client/Server/ScheduleTask/DeleteScheduleTaskTest.php
@@ -37,7 +37,7 @@ class DeleteScheduleTaskTest extends ClientApiIntegrationTestCase
         $schedule2 = Schedule::factory()->create(['server_id' => $server->id]);
         $task = Task::factory()->create(['schedule_id' => $schedule->id]);
 
-        $this->actingAs($user)->deleteJson("/api/client/servers/$server->uuid/schedules/$schedule2->id/tasks/$task->id")->assertNotFound();
+        $this->actingAs($user)->deleteJson("/api/client/services/$server->uuid/schedules/$schedule2->id/tasks/$task->id")->assertNotFound();
     }
 
     /**

--- a/tests/Integration/Api/Client/Server/SettingsControllerTest.php
+++ b/tests/Integration/Api/Client/Server/SettingsControllerTest.php
@@ -22,7 +22,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $originalName = $server->name;
         $originalDescription = $server->description;
 
-        $response = $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/settings/rename", [
+        $response = $this->actingAs($user)->postJson("/api/client/services/$server->uuid/settings/rename", [
             'name' => '',
             'description' => '',
         ]);
@@ -35,7 +35,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $this->assertSame($originalDescription, $server->description);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/settings/rename", [
+            ->postJson("/api/client/services/$server->uuid/settings/rename", [
                 'name' => 'Test Server Name',
                 'description' => 'This is a test server.',
             ])
@@ -56,7 +56,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         $originalName = $server->name;
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/settings/rename", [
+            ->postJson("/api/client/services/$server->uuid/settings/rename", [
                 'name' => 'Test Server Name',
             ])
             ->assertStatus(Response::HTTP_FORBIDDEN);
@@ -89,7 +89,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
             ->expects('reinstall')
             ->andReturnUndefined();
 
-        $this->actingAs($user)->postJson("/api/client/servers/$server->uuid/settings/reinstall")
+        $this->actingAs($user)->postJson("/api/client/services/$server->uuid/settings/reinstall")
             ->assertStatus(Response::HTTP_ACCEPTED);
 
         $server = $server->refresh();
@@ -105,7 +105,7 @@ class SettingsControllerTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_WEBSOCKET_CONNECT]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/settings/reinstall")
+            ->postJson("/api/client/services/$server->uuid/settings/reinstall")
             ->assertStatus(Response::HTTP_FORBIDDEN);
 
         $server = $server->refresh();

--- a/tests/Integration/Api/Client/Server/Subuser/UpdateSubuserTest.php
+++ b/tests/Integration/Api/Client/Server/Subuser/UpdateSubuserTest.php
@@ -25,7 +25,7 @@ class UpdateSubuserTest extends ClientApiIntegrationTestCase
             ]);
 
         $this->postJson(
-            $endpoint = "/api/client/servers/$server->uuid/users/{$subuser->user->uuid}",
+            $endpoint = "/api/client/services/$server->uuid/users/{$subuser->user->uuid}",
             $data = [
                 'permissions' => [
                     'control.start',
@@ -66,7 +66,7 @@ class UpdateSubuserTest extends ClientApiIntegrationTestCase
             ]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/users/{$subuser->user->uuid}", [
+            ->postJson("/api/client/services/$server->uuid/users/{$subuser->user->uuid}", [
                 'permissions' => [
                     'control.start',
                     'control.stop',
@@ -98,7 +98,7 @@ class UpdateSubuserTest extends ClientApiIntegrationTestCase
             ->create(['permissions' => ['foo.bar']]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/users/{$subuser->user->uuid}", [
+            ->postJson("/api/client/services/$server->uuid/users/{$subuser->user->uuid}", [
                 'permissions' => [Permission::ACTION_USER_READ, Permission::ACTION_CONTROL_CONSOLE],
             ])
             ->assertForbidden();
@@ -114,7 +114,7 @@ class UpdateSubuserTest extends ClientApiIntegrationTestCase
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_USER_READ, Permission::ACTION_USER_UPDATE]);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/users/$user->uuid", [])
+            ->postJson("/api/client/services/$server->uuid/users/$user->uuid", [])
             ->assertForbidden();
     }
 
@@ -127,7 +127,7 @@ class UpdateSubuserTest extends ClientApiIntegrationTestCase
         [$user2] = $this->generateTestAccount(['foo.bar']);
 
         $this->actingAs($user)
-            ->postJson("/api/client/servers/$server->uuid/users/$user2->uuid", [])
+            ->postJson("/api/client/services/$server->uuid/users/$user2->uuid", [])
             ->assertNotFound();
     }
 }

--- a/tests/Integration/Api/Client/Server/WebsocketControllerTest.php
+++ b/tests/Integration/Api/Client/Server/WebsocketControllerTest.php
@@ -21,7 +21,7 @@ class WebsocketControllerTest extends ClientApiIntegrationTestCase
     {
         [$user, $server] = $this->generateTestAccount([Permission::ACTION_CONTROL_RESTART]);
 
-        $this->actingAs($user)->getJson("/api/client/servers/$server->uuid/websocket")
+        $this->actingAs($user)->getJson("/api/client/services/$server->uuid/websocket")
             ->assertStatus(Response::HTTP_FORBIDDEN)
             ->assertJsonPath('errors.0.code', 'HttpForbiddenException')
             ->assertJsonPath('errors.0.detail', 'You do not have permission to connect to this server\'s websocket.');
@@ -35,7 +35,7 @@ class WebsocketControllerTest extends ClientApiIntegrationTestCase
         [, $server] = $this->generateTestAccount([Permission::ACTION_WEBSOCKET_CONNECT]);
         [$user] = $this->generateTestAccount([Permission::ACTION_WEBSOCKET_CONNECT]);
 
-        $this->actingAs($user)->getJson("/api/client/servers/$server->uuid/websocket")
+        $this->actingAs($user)->getJson("/api/client/services/$server->uuid/websocket")
             ->assertStatus(Response::HTTP_NOT_FOUND);
     }
 
@@ -53,14 +53,14 @@ class WebsocketControllerTest extends ClientApiIntegrationTestCase
         $server->node->scheme = 'https';
         $server->node->save();
 
-        $response = $this->actingAs($user)->getJson("/api/client/servers/$server->uuid/websocket");
+        $response = $this->actingAs($user)->getJson("/api/client/services/$server->uuid/websocket");
 
         $response->assertOk();
         $response->assertJsonStructure(['data' => ['token', 'socket']]);
 
         $connection = $response->json('data.socket');
         $this->assertStringStartsWith('wss://', $connection, 'Failed asserting that websocket connection address has expected "wss://" prefix.');
-        $this->assertStringEndsWith("/api/servers/$server->uuid/ws", $connection, 'Failed asserting that websocket connection address uses expected Wings endpoint.');
+        $this->assertStringEndsWith("/api/services/$server->uuid/ws", $connection, 'Failed asserting that websocket connection address uses expected Wings endpoint.');
 
         $config = Configuration::forSymmetricSigner(new Sha256(), $key = InMemory::plainText($server->node->getDecryptedKey()));
         $config->setValidationConstraints(new SignedWith(new Sha256(), $key));
@@ -102,7 +102,7 @@ class WebsocketControllerTest extends ClientApiIntegrationTestCase
         /** @var \Pterodactyl\Models\Server $server */
         [$user, $server] = $this->generateTestAccount($permissions);
 
-        $response = $this->actingAs($user)->getJson("/api/client/servers/$server->uuid/websocket");
+        $response = $this->actingAs($user)->getJson("/api/client/services/$server->uuid/websocket");
 
         $response->assertOk();
         $response->assertJsonStructure(['data' => ['token', 'socket']]);


### PR DESCRIPTION
## Summary
- remove Wings integration by returning dummy responses
- update routes and controllers from servers to services
- adjust frontend endpoints and admin links to use `/services`
- rename router paths from `/server/:id` to `/services/:id`
- replace "wings" mentions in UI with "daemon"

